### PR TITLE
Improve colors and unify play-again quit logic

### DIFF
--- a/plinko-board.js
+++ b/plinko-board.js
@@ -7,14 +7,14 @@ const PLINKO_CONFIG = {
     PEG_HEIGHT_BOXES: 1.25,     // Height of standard pegs
     RA_PEG_WIDTH_BOXES: 1.75,   // Original default width for RA pegs (not directly used for these side pegs)
     RA_PEG_HEIGHT_BOXES: 1.75,  // Base height for scaling side pegs
-    PEG_COLOR_FILL: '#888888',
-    PEG_COLOR_STROKE: '#333333',
-    GRID_COLOR: '#dddddd',
-    SLOT_LINE_COLOR: '#555555',
+    PEG_COLOR_FILL: '#03a9f4',
+    PEG_COLOR_STROKE: '#01579b',
+    GRID_COLOR: '#b0bec5',
+    SLOT_LINE_COLOR: '#ff5722',
     TEXT_COLOR: '#000000',
     TEXT_FONT: 'bold 14px Arial',
     BALL_RADIUS_BOXES: 0.35,
-    BALL_COLOR: 'red',
+    BALL_COLOR: '#ff4081',
 };
 
 let canvas, ctx;

--- a/script.js
+++ b/script.js
@@ -350,17 +350,15 @@ document.addEventListener('DOMContentLoaded', () => {
     if (playAgainBtn) {
         playAgainBtn.addEventListener('click', () => {
             console.log("Play Again button clicked. isGameActive:", isGameActive, "isOverlayVisible:", isOverlayVisible, "Player Money:", playerMoney);
-            // --- MODIFICATION START ---
-            // If player can't afford next round, force quit
+            // If player can't afford the next round, behave exactly like the
+            // "Quit Game & Save" button.
             if (playerMoney < rollCost) {
-                alert("You don't have enough money for the next round. Your session high score will be saved.");
-                gameOverOverlayEl.classList.add('hidden'); // Hide overlay before quit
+                gameOverOverlayEl.classList.add('hidden');
                 isOverlayVisible = false;
                 isGameActive = false;
-                handleQuitGame(); // This will save the sessionMaxMoney and go to name prompt
+                handleQuitGame();
                 return;
             }
-            // --- MODIFICATION END ---
 
             if (!isOverlayVisible && isGameActive) {
                 console.warn("Play Again clicked, but overlay isn't visible or game is already active. This shouldn't happen.");

--- a/style.css
+++ b/style.css
@@ -5,13 +5,13 @@ body {
     align-items: flex-start; /* Align to top for longer content */
     min-height: 100vh;
     margin: 0;
-    background-color: #f0f0f0;
+    background: linear-gradient(135deg, #e0f7fa, #ffe0f7);
     padding-top: 20px; /* Add some padding at the top */
 }
 
 #game-container {
     text-align: center;
-    background-color: #ffffff;
+    background: linear-gradient(to bottom, #ffffff, #fffde7);
     padding: 20px;
     border-radius: 10px;
     box-shadow: 0 0 15px rgba(0,0,0,0.1);
@@ -91,7 +91,7 @@ body {
     font-size: 24px;
     font-weight: bold;
     margin: 0 10px;
-    background-color: #fff;
+    background-color: #ffecb3;
     transition: transform 0.1s ease-out; /* For animation */
 }
 
@@ -113,24 +113,24 @@ body {
     padding: 12px 25px; /* Slightly larger padding */
     font-size: 18px;    /* Slightly larger font */
     cursor: pointer;
-    background-color: #4CAF50; /* Green for most actions */
+    background: linear-gradient(to bottom, #4CAF50, #2e7d32);
     color: white;
     border: none;
     border-radius: 5px;
     margin-top: 15px;
-    transition: background-color 0.3s ease;
+    transition: background 0.3s ease;
 }
 #quit-game-btn {
-    background-color: #f44336; /* Red for quit */
+    background: linear-gradient(to bottom, #f44336, #c62828);
     margin-left: 10px; /* Space it from play again if they are in the same container */
 }
 
 
 #roll-dice-btn:hover, #drop-ball-btn:hover, #play-again-btn:hover {
-    background-color: #45a049;
+    background: linear-gradient(to bottom, #66bb6a, #388e3c);
 }
 #quit-game-btn:hover {
-    background-color: #da190b;
+    background: linear-gradient(to bottom, #e53935, #b71c1c);
 }
 
 
@@ -158,11 +158,11 @@ body {
 }
 
 #dice-sum-table th {
-    background-color: #f2f2f2;
+    background-color: #ffe082;
 }
 
 #dice-sum-table tr.highlighted td {
-    background-color: #ffeb3b; /* Yellow highlight */
+    background-color: #ffab40; /* Orange highlight */
     font-weight: bold;
 }
 
@@ -226,14 +226,14 @@ body {
 
 #high-score-display {
     margin-top: 15px;
-    margin-bottom: 15px; 
+    margin-bottom: 15px;
     padding: 10px;
     border: 1px dashed #ccc;
     border-radius: 4px;
-    background-color: #f9f9f9;
+    background-color: #e1f5fe;
     max-height: 180px; /* Limit height for scores */
-    overflow-y: auto;   
-    text-align: left;   
+    overflow-y: auto;
+    text-align: left;
 }
 #high-score-display h3 {
     margin-top: 0;


### PR DESCRIPTION
## Summary
- brighten the UI with gradients and colourful highlights
- update Plinko board colours
- make the Play Next Round button act the same as Quit when out of money

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68434f58a9b4832891ba8fc9ef181ff6