### PR TITLE
Implement bad-word filtering for usernames

### DIFF
--- a/bad-words.js
+++ b/bad-words.js
@@ -1,0 +1,8 @@
+const BAD_WORDS = [
+    'badword1',
+    'badword2',
+    'curse',
+    'nasty'
+];
+
+window.BAD_WORDS = BAD_WORDS;

--- a/index.html
+++ b/index.html
@@ -74,6 +74,7 @@
 
     <script src="plinko-board.js"></script>
     <script src="physics.js"></script>
+    <script src="bad-words.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -30,6 +30,7 @@ document.addEventListener('DOMContentLoaded', () => {
     // Game State
     let currentPlayerName = "";
     let playerMoney = 0;
+    let badWordCount = 0; // Counter for filtered usernames
     // --- MODIFICATION START ---
     let sessionMaxMoney = 0; // To track the peak money during the current session
     // --- MODIFICATION END ---
@@ -71,6 +72,12 @@ document.addEventListener('DOMContentLoaded', () => {
             highScoreListEl.innerHTML = '<li>No scores yet!</li>';
             highScoreDisplayEl.classList.remove('hidden');
         }
+    }
+
+    function containsBadWord(name) {
+        if (!Array.isArray(window.BAD_WORDS)) return false;
+        const lower = name.toLowerCase();
+        return window.BAD_WORDS.some(word => lower.includes(word.toLowerCase()));
     }
 
     // --- UI UPDATE FUNCTIONS ---
@@ -127,6 +134,10 @@ document.addEventListener('DOMContentLoaded', () => {
         if (!currentPlayerName) {
             alert("Please enter a name to start!");
             return;
+        }
+        if (containsBadWord(currentPlayerName)) {
+            badWordCount += 1;
+            currentPlayerName = `I-put-in-a-bad-word(${badWordCount})`;
         }
         playerMoney = initialPlayerMoney;
         // --- MODIFICATION START ---


### PR DESCRIPTION
## Summary
- add `bad-words.js` with placeholder bad words
- load the bad-word list in `index.html`
- filter usernames in `script.js` using the bad words list

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6844bd1da6388328966bfcea80dd1de1