### PR TITLE
Fix slot divider collision

### DIFF
--- a/plinko-board.js
+++ b/plinko-board.js
@@ -185,6 +185,23 @@ function drawRectPeg(xInBoxes, yInBoxes, widthInBoxes, heightInBoxes) {
     });
 }
 
+function addRectPeg(xInBoxes, yInBoxes, widthInBoxes, heightInBoxes) {
+    if (!ctx) return;
+    const pixelX = xInBoxes * PLINKO_CONFIG.BOX_SIZE;
+    const pixelY = yInBoxes * PLINKO_CONFIG.BOX_SIZE;
+    const pixelWidth = widthInBoxes * PLINKO_CONFIG.BOX_SIZE;
+    const pixelHeight = heightInBoxes * PLINKO_CONFIG.BOX_SIZE;
+
+    pegs.push({
+        type: 'rect',
+        x: pixelX,
+        y: pixelY,
+        width: pixelWidth,
+        height: pixelHeight,
+        center: { x: pixelX + pixelWidth / 2, y: pixelY + pixelHeight / 2 }
+    });
+}
+
 
 function drawTopSlotLabels() {
     if (!ctx) return;
@@ -285,9 +302,13 @@ function defineBottomSlotsAndDraw(lowestPegBaseYInBoxes) {
             ctx.lineTo(i * PLINKO_CONFIG.BOX_SIZE, canvas.height);
             ctx.stroke();
 
-            const capWidth = 0.5;
-            const capHeight = 0.25;
-            drawRectPeg(i - capWidth / 2, prizeSlotTopYBox - capHeight, capWidth, capHeight);
+            const pegWidth = 0.2;
+            addRectPeg(
+                i - pegWidth / 2,
+                prizeSlotTopYBox,
+                pegWidth,
+                PLINKO_CONFIG.BOARD_ROWS - prizeSlotTopYBox
+            );
         }
     }
     ctx.beginPath();


### PR DESCRIPTION
## Summary
- remove caps above dividers
- keep dividers visible but add hidden pegs along their height so the ball can't pass through

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68474a7b66f48328b460d4cf34715916