### PR TITLE
Add instructions popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             <label for="player-name-input">Enter your username:</label>
             <input type="text" id="player-name-input" maxlength="15">
             <button id="start-game-btn">Start Game</button>
+            <button id="instructions-btn" type="button">How to Play</button>
         </div>
 
 
@@ -62,12 +63,22 @@
                 <p id="final-money-message"></p>
                 <div id="high-score-display">
                     <h3>Top Scores:</h3>
-                    <ol id="high-score-list"></ol> 
+                    <ol id="high-score-list"></ol>
                 </div>
                 <div class="game-over-buttons">
-                    <button id="play-again-btn">Play Next Round</button> 
-                    <button id="quit-game-btn">Quit Game & Save</button> 
+                    <button id="play-again-btn">Play Next Round</button>
+                    <button id="quit-game-btn">Quit Game & Save</button>
                 </div>
+            </div>
+        </div>
+
+        <!-- Instructions Overlay -->
+        <div id="instructions-overlay" class="overlay hidden">
+            <div class="overlay-content">
+                <h2>Game Instructions</h2>
+                <p>Roll the dice to choose a slot and drop the ball. Win or lose cash based on where the ball lands. Try to set a high score!</p>
+                <p><strong>Plink-o-Die 2</strong> is fast, fun and free. Share the game with friends and check out our other titles!</p>
+                <button id="close-instructions-btn">Close</button>
             </div>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -7,10 +7,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const namePromptStageEl = document.getElementById('name-prompt-stage');
     const playerNameInputEl = document.getElementById('player-name-input');
     const startGameBtn = document.getElementById('start-game-btn');
+    const instructionsBtn = document.getElementById('instructions-btn');
 
     const diceStageEl = document.getElementById('dice-stage');
     const plinkoStageEl = document.getElementById('plinko-stage');
     const gameOverOverlayEl = document.getElementById('game-over-overlay');
+    const instructionsOverlayEl = document.getElementById('instructions-overlay');
+    const closeInstructionsBtn = document.getElementById('close-instructions-btn');
 
     const dice1El = document.getElementById('dice1');
     const dice2El = document.getElementById('dice2');
@@ -309,6 +312,14 @@ document.addEventListener('DOMContentLoaded', () => {
         });
     }
 
+    function showInstructionsOverlay() {
+        if (instructionsOverlayEl) instructionsOverlayEl.classList.remove('hidden');
+    }
+
+    function hideInstructionsOverlay() {
+        if (instructionsOverlayEl) instructionsOverlayEl.classList.add('hidden');
+    }
+
     function transitionToPlinko() {
         if (!isGameActive || isOverlayVisible) {
             console.warn("Transition to Plinko attempt while game not active or overlay visible.");
@@ -373,6 +384,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (startGameBtn) startGameBtn.addEventListener('click', startGameSession);
     if (rollDiceBtn) rollDiceBtn.addEventListener('click', rollDice);
     if (dropBallBtn) dropBallBtn.addEventListener('click', onDropBallClicked);
+    if (instructionsBtn) instructionsBtn.addEventListener('click', showInstructionsOverlay);
+    if (closeInstructionsBtn) closeInstructionsBtn.addEventListener('click', hideInstructionsOverlay);
 
     if (playAgainBtn) {
         playAgainBtn.addEventListener('click', () => {

--- a/style.css
+++ b/style.css
@@ -117,7 +117,7 @@ body {
 }
 
 
-#roll-dice-btn, #drop-ball-btn, #play-again-btn, #quit-game-btn {
+#roll-dice-btn, #drop-ball-btn, #play-again-btn, #quit-game-btn, #close-instructions-btn {
     padding: 12px 25px; /* Slightly larger padding */
     font-size: 18px;    /* Slightly larger font */
     cursor: pointer;
@@ -135,7 +135,7 @@ body {
 }
 
 
-#roll-dice-btn:hover, #drop-ball-btn:hover, #play-again-btn:hover {
+#roll-dice-btn:hover, #drop-ball-btn:hover, #play-again-btn:hover, #close-instructions-btn:hover {
     opacity: 0.8;
 }
 #quit-game-btn:hover {


### PR DESCRIPTION
## Summary
- add a How to Play button under the username field
- include an instructions overlay describing the game
- wire up show/hide logic in JS
- style the overlay button like other actions

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68489df658408328be0d45ac41d74045