### PR TITLE
Add animated demo board to instructions

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,6 +78,7 @@
                 <h2>Game Instructions</h2>
                 <p>Roll the dice to choose a slot and drop the ball. Win or lose cash based on where the ball lands. Try to set a high score!</p>
                 <p><strong>Plink-o-Die 2</strong> is fast, fun and free. Share the game with friends and check out our other titles!</p>
+                <canvas id="miniPlinkoCanvas" width="220" height="180"></canvas>
                 <button id="close-instructions-btn">Close</button>
             </div>
         </div>
@@ -85,7 +86,8 @@
 
     <script src="plinko-board.js"></script>
     <script src="physics.js"></script>
+    <script src="mini-plinko.js"></script>
     <script src="bad-words.js"></script>
     <script src="script.js"></script>
-</body>
+    </body>
 </html>

--- a/mini-plinko.js
+++ b/mini-plinko.js
@@ -1,0 +1,119 @@
+(function() {
+    const CONFIG = {
+        SLOT_COUNT: 5,
+        SLOT_WIDTH: 40,
+        BOARD_HEIGHT: 160,
+        BOARD_PADDING: 10,
+        BALL_RADIUS: 5,
+        GRAVITY: 0.3
+    };
+
+    let canvas, ctx;
+    let ball;
+    let vy;
+    let vx;
+    let animationId = null;
+    let nextPegIndex;
+
+    function init() {
+        canvas = document.getElementById('miniPlinkoCanvas');
+        if (!canvas) return;
+        ctx = canvas.getContext('2d');
+        canvas.width = CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT + CONFIG.BOARD_PADDING * 2;
+        canvas.height = CONFIG.BOARD_HEIGHT + CONFIG.BOARD_PADDING * 2;
+        resetBall();
+    }
+
+    function resetBall() {
+        if (!canvas) return;
+        const slot = Math.floor(Math.random() * CONFIG.SLOT_COUNT);
+        const startX = CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * slot + CONFIG.SLOT_WIDTH / 2;
+        ball = { x: startX, y: CONFIG.BOARD_PADDING + CONFIG.BALL_RADIUS, radius: CONFIG.BALL_RADIUS };
+        vy = 1;
+        vx = 0;
+        nextPegIndex = 0;
+        drawBoard();
+    }
+
+    function drawBoard() {
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        ctx.strokeStyle = '#0ff';
+        for (let i = 0; i <= CONFIG.SLOT_COUNT; i++) {
+            const x = CONFIG.BOARD_PADDING + i * CONFIG.SLOT_WIDTH;
+            ctx.beginPath();
+            ctx.moveTo(x, CONFIG.BOARD_PADDING);
+            ctx.lineTo(x, canvas.height - CONFIG.BOARD_PADDING);
+            ctx.stroke();
+        }
+        ctx.beginPath();
+        ctx.moveTo(CONFIG.BOARD_PADDING, canvas.height - CONFIG.BOARD_PADDING);
+        ctx.lineTo(CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT, canvas.height - CONFIG.BOARD_PADDING);
+        ctx.stroke();
+    }
+
+    const PEG_Y_POSITIONS = [30, 60, 90, 120];
+
+    function update() {
+        ball.y += vy;
+        ball.x += vx;
+
+        if (nextPegIndex < PEG_Y_POSITIONS.length &&
+            ball.y - CONFIG.BOARD_PADDING >= PEG_Y_POSITIONS[nextPegIndex]) {
+            vx += (Math.random() - 0.5) * 2;
+            nextPegIndex++;
+        }
+
+        const leftBound = CONFIG.BOARD_PADDING + ball.radius;
+        const rightBound = CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT - ball.radius;
+        if (ball.x <= leftBound || ball.x >= rightBound) {
+            ball.x = Math.max(leftBound, Math.min(rightBound, ball.x));
+            vx *= -0.6;
+        }
+
+        vy += CONFIG.GRAVITY;
+
+        if (ball.y >= canvas.height - CONFIG.BOARD_PADDING - ball.radius) {
+            ball.y = canvas.height - CONFIG.BOARD_PADDING - ball.radius;
+            vy = 0;
+            vx = 0;
+            cancelAnimationFrame(animationId);
+            animationId = null;
+            setTimeout(() => {
+                resetBall();
+                start();
+            }, 1000);
+        }
+    }
+
+    function draw() {
+        drawBoard();
+        ctx.beginPath();
+        ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
+        ctx.fillStyle = '#ff4081';
+        ctx.fill();
+        ctx.strokeStyle = '#fff';
+        ctx.stroke();
+    }
+
+    function loop() {
+        update();
+        draw();
+        animationId = requestAnimationFrame(loop);
+    }
+
+    function start() {
+        if (!canvas) init();
+        if (animationId) cancelAnimationFrame(animationId);
+        animationId = requestAnimationFrame(loop);
+    }
+
+    function stop() {
+        if (animationId) {
+            cancelAnimationFrame(animationId);
+            animationId = null;
+        }
+    }
+
+    window.startMiniPlinkoDemo = start;
+    window.stopMiniPlinkoDemo = stop;
+})();

--- a/script.js
+++ b/script.js
@@ -313,11 +313,17 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     function showInstructionsOverlay() {
-        if (instructionsOverlayEl) instructionsOverlayEl.classList.remove('hidden');
+        if (instructionsOverlayEl) {
+            instructionsOverlayEl.classList.remove('hidden');
+            if (typeof startMiniPlinkoDemo === 'function') startMiniPlinkoDemo();
+        }
     }
 
     function hideInstructionsOverlay() {
-        if (instructionsOverlayEl) instructionsOverlayEl.classList.add('hidden');
+        if (instructionsOverlayEl) {
+            instructionsOverlayEl.classList.add('hidden');
+            if (typeof stopMiniPlinkoDemo === 'function') stopMiniPlinkoDemo();
+        }
     }
 
     function transitionToPlinko() {

--- a/style.css
+++ b/style.css
@@ -277,9 +277,18 @@ body {
     border-bottom: none;
 }
 
-.game-over-buttons { 
+.game-over-buttons {
     margin-top: 15px;
     display: flex; /* For better button alignment if needed */
     justify-content: center; /* Center buttons */
     gap: 10px; /* Space between buttons */
+}
+
+/* Mini plinko board in instructions overlay */
+#miniPlinkoCanvas {
+    display: block;
+    margin: 10px auto;
+    border: 1px solid #0ff;
+    background-color: #000;
+    box-shadow: 0 0 10px #0ff;
 }


### PR DESCRIPTION
## Summary
- display a small plinko board inside the instructions overlay
- animate a demo ball that repeatedly chooses a random slot
- start/stop the demo when instructions are opened/closed

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68489f6eb33c83289937d9798b8bdb13