### PR TITLE
Replace mini plinko demo with automated dice

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,7 +78,10 @@
                 <h2>Game Instructions</h2>
                 <p>Roll the dice to choose a slot and drop the ball. Win or lose cash based on where the ball lands. Try to set a high score!</p>
                 <p><strong>Plink-o-Die 2</strong> is fast, fun and free. Share the game with friends and check out our other titles!</p>
-                <canvas id="miniPlinkoCanvas" width="220" height="180"></canvas>
+                <div id="instruction-dice-area" class="dice-area">
+                    <div class="dice mini-dice" id="instruction-dice1">1</div>
+                    <div class="dice mini-dice" id="instruction-dice2">1</div>
+                </div>
                 <button id="close-instructions-btn">Close</button>
             </div>
         </div>

--- a/mini-plinko.js
+++ b/mini-plinko.js
@@ -1,119 +1,63 @@
-(function() {
-    const CONFIG = {
-        SLOT_COUNT: 5,
-        SLOT_WIDTH: 40,
-        BOARD_HEIGHT: 160,
-        BOARD_PADDING: 10,
-        BALL_RADIUS: 5,
-        GRAVITY: 0.3
-    };
+// This file previously displayed a miniature Plinko board in the instructions
+// overlay. The instructions now show a pair of dice that repeatedly roll on
+// their own. This script handles that animation while keeping the original
+// startMiniPlinkoDemo/stopMiniPlinkoDemo API used elsewhere in the code base.
 
-    let canvas, ctx;
-    let ball;
-    let vy;
-    let vx;
-    let animationId = null;
-    let nextPegIndex;
+(function() {
+    let dice1El, dice2El;
+    let rollIntervalId = null;
+    let pauseTimeoutId = null;
 
     function init() {
-        canvas = document.getElementById('miniPlinkoCanvas');
-        if (!canvas) return;
-        ctx = canvas.getContext('2d');
-        canvas.width = CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT + CONFIG.BOARD_PADDING * 2;
-        canvas.height = CONFIG.BOARD_HEIGHT + CONFIG.BOARD_PADDING * 2;
-        resetBall();
+        dice1El = document.getElementById('instruction-dice1');
+        dice2El = document.getElementById('instruction-dice2');
     }
 
-    function resetBall() {
-        if (!canvas) return;
-        const slot = Math.floor(Math.random() * CONFIG.SLOT_COUNT);
-        const startX = CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * slot + CONFIG.SLOT_WIDTH / 2;
-        ball = { x: startX, y: CONFIG.BOARD_PADDING + CONFIG.BALL_RADIUS, radius: CONFIG.BALL_RADIUS };
-        vy = 1;
-        vx = 0;
-        nextPegIndex = 0;
-        drawBoard();
+    function showRandomValues() {
+        if (!dice1El || !dice2El) return;
+        dice1El.textContent = Math.floor(Math.random() * 6) + 1;
+        dice2El.textContent = Math.floor(Math.random() * 6) + 1;
     }
 
-    function drawBoard() {
-        ctx.clearRect(0, 0, canvas.width, canvas.height);
-        ctx.strokeStyle = '#0ff';
-        for (let i = 0; i <= CONFIG.SLOT_COUNT; i++) {
-            const x = CONFIG.BOARD_PADDING + i * CONFIG.SLOT_WIDTH;
-            ctx.beginPath();
-            ctx.moveTo(x, CONFIG.BOARD_PADDING);
-            ctx.lineTo(x, canvas.height - CONFIG.BOARD_PADDING);
-            ctx.stroke();
-        }
-        ctx.beginPath();
-        ctx.moveTo(CONFIG.BOARD_PADDING, canvas.height - CONFIG.BOARD_PADDING);
-        ctx.lineTo(CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT, canvas.height - CONFIG.BOARD_PADDING);
-        ctx.stroke();
-    }
+    function rollOnce() {
+        if (!dice1El || !dice2El) return;
+        let ticks = 0;
+        const maxTicks = 10; // run animation for ~1s
+        dice1El.classList.add('rolling');
+        dice2El.classList.add('rolling');
 
-    const PEG_Y_POSITIONS = [30, 60, 90, 120];
-
-    function update() {
-        ball.y += vy;
-        ball.x += vx;
-
-        if (nextPegIndex < PEG_Y_POSITIONS.length &&
-            ball.y - CONFIG.BOARD_PADDING >= PEG_Y_POSITIONS[nextPegIndex]) {
-            vx += (Math.random() - 0.5) * 2;
-            nextPegIndex++;
-        }
-
-        const leftBound = CONFIG.BOARD_PADDING + ball.radius;
-        const rightBound = CONFIG.BOARD_PADDING + CONFIG.SLOT_WIDTH * CONFIG.SLOT_COUNT - ball.radius;
-        if (ball.x <= leftBound || ball.x >= rightBound) {
-            ball.x = Math.max(leftBound, Math.min(rightBound, ball.x));
-            vx *= -0.6;
-        }
-
-        vy += CONFIG.GRAVITY;
-
-        if (ball.y >= canvas.height - CONFIG.BOARD_PADDING - ball.radius) {
-            ball.y = canvas.height - CONFIG.BOARD_PADDING - ball.radius;
-            vy = 0;
-            vx = 0;
-            cancelAnimationFrame(animationId);
-            animationId = null;
-            setTimeout(() => {
-                resetBall();
-                start();
-            }, 1000);
-        }
-    }
-
-    function draw() {
-        drawBoard();
-        ctx.beginPath();
-        ctx.arc(ball.x, ball.y, ball.radius, 0, Math.PI * 2);
-        ctx.fillStyle = '#ff4081';
-        ctx.fill();
-        ctx.strokeStyle = '#fff';
-        ctx.stroke();
-    }
-
-    function loop() {
-        update();
-        draw();
-        animationId = requestAnimationFrame(loop);
+        rollIntervalId = setInterval(() => {
+            showRandomValues();
+            ticks++;
+            if (ticks >= maxTicks) {
+                clearInterval(rollIntervalId);
+                rollIntervalId = null;
+                dice1El.classList.remove('rolling');
+                dice2El.classList.remove('rolling');
+                showRandomValues();
+                pauseTimeoutId = setTimeout(rollOnce, 2000); // pause before next roll
+            }
+        }, 100);
     }
 
     function start() {
-        if (!canvas) init();
-        if (animationId) cancelAnimationFrame(animationId);
-        animationId = requestAnimationFrame(loop);
+        if (!dice1El || !dice2El) init();
+        stop();
+        rollOnce();
     }
 
     function stop() {
-        if (animationId) {
-            cancelAnimationFrame(animationId);
-            animationId = null;
+        if (rollIntervalId) {
+            clearInterval(rollIntervalId);
+            rollIntervalId = null;
+        }
+        if (pauseTimeoutId) {
+            clearTimeout(pauseTimeoutId);
+            pauseTimeoutId = null;
         }
     }
 
+    // Preserve original API names so other files don't need changes
     window.startMiniPlinkoDemo = start;
     window.stopMiniPlinkoDemo = stop;
 })();

--- a/style.css
+++ b/style.css
@@ -284,11 +284,16 @@ body {
     gap: 10px; /* Space between buttons */
 }
 
-/* Mini plinko board in instructions overlay */
-#miniPlinkoCanvas {
-    display: block;
-    margin: 10px auto;
-    border: 1px solid #0ff;
-    background-color: #000;
-    box-shadow: 0 0 10px #0ff;
+/* Animated dice shown in the instructions overlay */
+#instruction-dice-area {
+    display: flex;
+    justify-content: center;
+    margin: 10px 0;
+}
+
+.mini-dice {
+    width: 40px;
+    height: 40px;
+    font-size: 20px;
+    margin: 0 5px;
 }


### PR DESCRIPTION
## Summary
- swap instructions overlay canvas for two mini dice
- style and animate the mini dice
- implement new looping dice animation instead of mini plinko board

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848a14a395483288808a85272a161a4