### PR TITLE
Add mini plinko demo and load dice roller

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
                     <div id="instruction-dice1" class="mini-dice">1</div>
                     <div id="instruction-dice2" class="mini-dice">1</div>
                 </div>
+                <canvas id="mini-plinko-canvas"></canvas>
                 <button id="close-instructions-btn">Close</button>
             </div>
         </div>
@@ -90,6 +91,7 @@
     <script src="plinko-board.js"></script>
     <script src="physics.js"></script>
     <script src="bad-words.js"></script>
+    <script src="mini-plinko.js"></script>
     <script src="script.js"></script>
 </body>
 </html>

--- a/mini-plinko.js
+++ b/mini-plinko.js
@@ -7,10 +7,15 @@
     let dice1El, dice2El;
     let rollIntervalId = null;
     let pauseTimeoutId = null;
+    let miniCanvas;
 
     function init() {
         dice1El = document.getElementById('instruction-dice1');
         dice2El = document.getElementById('instruction-dice2');
+        miniCanvas = document.getElementById('mini-plinko-canvas');
+        if (miniCanvas && typeof drawScaledPlinkoBoardOnCanvas === 'function') {
+            drawScaledPlinkoBoardOnCanvas(miniCanvas, 0.4);
+        }
     }
 
     function showRandomValues() {
@@ -41,9 +46,12 @@
     }
 
     function start() {
-        if (!dice1El || !dice2El) init();
+        if (!dice1El || !dice2El || !miniCanvas) init();
         stop();
         rollOnce();
+        if (miniCanvas && typeof drawScaledPlinkoBoardOnCanvas === 'function') {
+            drawScaledPlinkoBoardOnCanvas(miniCanvas, 0.4);
+        }
     }
 
     function stop() {

--- a/plinko-board.js
+++ b/plinko-board.js
@@ -422,6 +422,43 @@ function drawFullPlinkoBoard() {
     defineBottomSlotsAndDraw(lowestPegY);
 }
 
+// Draw the Plinko board on a specific canvas scaled by a factor without
+// disturbing the main game state. Used for the mini demo.
+function drawScaledPlinkoBoardOnCanvas(targetCanvas, scale) {
+    if (!targetCanvas || !targetCanvas.getContext) return;
+
+    const savedCanvas = canvas;
+    const savedCtx = ctx;
+    const savedBox = PLINKO_CONFIG.BOX_SIZE;
+    const savedPegs = pegs;
+    const savedSlots = bottomPrizeSlots;
+
+    canvas = targetCanvas;
+    ctx = targetCanvas.getContext('2d');
+    PLINKO_CONFIG.BOX_SIZE = savedBox * scale;
+    canvas.width = PLINKO_CONFIG.BOARD_COLS * PLINKO_CONFIG.BOX_SIZE;
+    canvas.height = PLINKO_CONFIG.BOARD_ROWS * PLINKO_CONFIG.BOX_SIZE;
+
+    pegs = [];
+    bottomPrizeSlots = [];
+
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    drawGrid();
+    drawTopSlotLabels();
+    const lowestPegY = definePegsAndDraw();
+    defineBottomSlotsAndDraw(lowestPegY);
+
+    // Restore originals so the main game is unaffected
+    PLINKO_CONFIG.BOX_SIZE = savedBox;
+    canvas = savedCanvas;
+    ctx = savedCtx;
+    pegs = savedPegs;
+    bottomPrizeSlots = savedSlots;
+}
+
+// Expose helper for other scripts
+window.drawScaledPlinkoBoardOnCanvas = drawScaledPlinkoBoardOnCanvas;
+
 // --- Example Usage (ensure you have an HTML file with <canvas id="plinkoCanvas"></canvas>) ---
 //
 // window.onload = () => {

--- a/style.css
+++ b/style.css
@@ -297,3 +297,12 @@ body {
     font-size: 20px;
     margin: 0 5px;
 }
+
+/* Mini Plinko board displayed in the instructions overlay */
+#mini-plinko-canvas {
+    display: block;
+    margin: 10px auto;
+    border: 1px solid #0ff;
+    background-color: #000;
+    box-shadow: 0 0 10px #0ff;
+}


### PR DESCRIPTION
## Summary
- add missing mini-plinko script to page
- show a scaled down plinko board in the instructions overlay
- expose a helper to draw the board at a smaller scale
- style the mini canvas

## Testing
- `node --check mini-plinko.js`
- `node --check plinko-board.js`

------
https://chatgpt.com/codex/tasks/task_e_6848afeb34e88328868dc738aab1fc82