### PR TITLE
Make instructions overlay full screen

### DIFF
--- a/style.css
+++ b/style.css
@@ -306,3 +306,14 @@ body {
     background-color: #000;
     box-shadow: 0 0 10px #0ff;
 }
+
+/* Make the instructions overlay fill the entire screen */
+#instructions-overlay .overlay-content {
+    width: 100%;
+    height: 100%;
+    max-width: none;
+    border-radius: 0;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}


### PR DESCRIPTION
## Summary
- let instructions overlay content take up entire screen

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848b7540fb48328be99740b72d7651f