### PR TITLE
Highlight active player on leaderboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -68,6 +68,9 @@ document.addEventListener('DOMContentLoaded', () => {
             scores.forEach(entry => {
                 const listItem = document.createElement('li');
                 listItem.textContent = `${entry.name}: $${entry.score}`;
+                if (entry.name === currentPlayerName) {
+                    listItem.classList.add('current-player-score');
+                }
                 highScoreListEl.appendChild(listItem);
             });
             highScoreDisplayEl.classList.remove('hidden');

--- a/style.css
+++ b/style.css
@@ -273,6 +273,11 @@ body {
     border-bottom: 1px solid #0ff;
     color: #0ff;
 }
+#high-score-list li.current-player-score {
+    color: #ff8800;
+    text-shadow: 0 0 8px #ff8800;
+    font-weight: bold;
+}
 #high-score-list li:last-child {
     border-bottom: none;
 }


### PR DESCRIPTION
## Summary
- highlight current player's score in Top Scores list
- style new `.current-player-score` as neon orange

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6848c37974a883289124f43d96976157